### PR TITLE
History based pruning

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,9 +380,9 @@ pub fn search<Search: SearchType>(
             In low depth, non-PV nodes, we assume it's safe to prune a move
             if it has very low history
             */
-            let do_hp = !Search::PV && is_quiet && depth <= 2;
+            let do_hp = !Search::PV && is_quiet;
 
-            if do_hp && h_score <= -(h_table::MAX_VALUE as i16) / 2 {
+            if do_hp && h_score <= -(h_table::MAX_VALUE as i16) * (depth as i16) / 5 {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -6,6 +6,7 @@ use crate::bm::bm_eval::eval::Evaluation;
 use crate::bm::bm_eval::evaluator::StdEvaluator;
 use crate::bm::bm_runner::ab_runner::{LocalContext, SharedContext, SEARCH_PARAMS};
 use crate::bm::bm_search::move_entry::MoveEntry;
+use crate::bm::bm_util::h_table;
 use crate::bm::bm_util::position::Position;
 use crate::bm::bm_util::t_table::EntryType::{Exact, LowerBound, UpperBound};
 use crate::bm::bm_util::t_table::{Analysis, EntryType};
@@ -375,12 +376,22 @@ pub fn search<Search: SearchType>(
                 continue;
             }
 
-            let do_see_prune = !Search::PV && !in_check && depth <= 2;
+            /*
+            In low depth, non-PV nodes, we assume it's safe to prune a move
+            if it has very low history
+            */
+            let do_hp = !Search::PV && is_quiet && depth <= 2;
+
+            if do_hp && h_score <= -(h_table::MAX_VALUE as i16) / 2 {
+                position.unmake_move();
+                continue;
+            }
 
             /*
             In non-PV nodes If a move evaluated by SEE isn't good enough to beat alpha - a static margin
             we assume it's safe to prune this move
             */
+            let do_see_prune = !Search::PV && !in_check && depth <= 2;
             if do_see_prune
                 && eval + StdEvaluator::see(board, make_move) + SEARCH_PARAMS.get_fp() < alpha
             {

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -382,7 +382,7 @@ pub fn search<Search: SearchType>(
             */
             let do_hp = !Search::PV && is_quiet && depth <= 10 && eval <= alpha;
 
-            if do_hp && h_score < -(h_table::MAX_VALUE as i16) * ((depth * depth) as i16) / 100 {
+            if do_hp && (h_score as i32) < (-h_table::MAX_VALUE * ((depth * depth) as i32) / 100) {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -382,7 +382,7 @@ pub fn search<Search: SearchType>(
             */
             let do_hp = !Search::PV && is_quiet;
 
-            if do_hp && h_score <= -(h_table::MAX_VALUE as i16) * (depth as i16) / 5 {
+            if do_hp && h_score <= -(h_table::MAX_VALUE as i16) * (depth.saturating_sub(3) as i16) / 7 {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,9 +380,9 @@ pub fn search<Search: SearchType>(
             In low depth, non-PV nodes, we assume it's safe to prune a move
             if it has very low history
             */
-            let do_hp = !Search::PV && is_quiet && depth <= 10 && eval <= alpha;
+            let do_hp = !Search::PV && is_quiet && depth <= 8 && eval <= alpha;
 
-            if do_hp && (h_score as i32) < (-h_table::MAX_VALUE * ((depth * depth) as i32) / 100) {
+            if do_hp && (h_score as i32) < (-h_table::MAX_VALUE * ((depth * depth) as i32) / 64) {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -382,7 +382,7 @@ pub fn search<Search: SearchType>(
             */
             let do_hp = !Search::PV && is_quiet;
 
-            if do_hp && h_score <= -(h_table::MAX_VALUE as i16) * (depth.saturating_sub(3) as i16) / 7 {
+            if do_hp && h_score < -(h_table::MAX_VALUE as i16) * (depth.saturating_sub(3) as i16) / 7 {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,7 +380,7 @@ pub fn search<Search: SearchType>(
             In low depth, non-PV nodes, we assume it's safe to prune a move
             if it has very low history
             */
-            let do_hp = !Search::PV && is_quiet && depth <= 10;
+            let do_hp = !Search::PV && is_quiet && depth <= 10 && eval <= alpha;
 
             if do_hp && h_score < -(h_table::MAX_VALUE as i16) * ((depth * depth) as i16) / 100 {
                 position.unmake_move();

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -382,7 +382,7 @@ pub fn search<Search: SearchType>(
             */
             let do_hp = !Search::PV && is_quiet;
 
-            if do_hp && h_score < -(h_table::MAX_VALUE as i16) * (depth.saturating_sub(3) as i16) / 7 {
+            if do_hp && h_score < -(h_table::MAX_VALUE as i16) * (depth.saturating_sub(3) as i16) / 4 {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -380,9 +380,9 @@ pub fn search<Search: SearchType>(
             In low depth, non-PV nodes, we assume it's safe to prune a move
             if it has very low history
             */
-            let do_hp = !Search::PV && is_quiet;
+            let do_hp = !Search::PV && is_quiet && depth <= 10;
 
-            if do_hp && h_score < -(h_table::MAX_VALUE as i16) * (depth.saturating_sub(3) as i16) / 4 {
+            if do_hp && h_score < -(h_table::MAX_VALUE as i16) * ((depth * depth) as i16) / 100 {
                 position.unmake_move();
                 continue;
             }

--- a/src/bm/bm_util/h_table.rs
+++ b/src/bm/bm_util/h_table.rs
@@ -1,6 +1,6 @@
 use chess::{Board, ChessMove, Color, Piece, Square};
 
-const MAX_VALUE: i32 = 512;
+pub const MAX_VALUE: i32 = 512;
 const SQUARE_COUNT: usize = 64;
 const PIECE_COUNT: usize = 12;
 


### PR DESCRIPTION
Prune moves with low history score if eval <= alpha