### PR TITLE
beta margin for NMP activation

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -177,7 +177,7 @@ pub fn search<Search: SearchType>(
             MIN_PIECE_CNT + board.pieces(Piece::Pawn).popcnt() == board.combined().popcnt();
         let do_null_move = SEARCH_PARAMS.do_nmp(depth) && Search::NM && !only_pawns;
 
-        if do_null_move && position.null_move() {
+        if do_null_move && eval >= beta && position.null_move() {
             {
                 let threat_table = local_context.get_threat_table();
                 while threat_table.len() <= ply as usize + 1 {


### PR DESCRIPTION
Do null move pruning only if eval is larger than beta