### PR TITLE
Remove RefCell from history tables

### DIFF
--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -197,8 +197,8 @@ pub struct LocalContext {
     eval_stack: Vec<Evaluation>,
     skip_moves: Vec<Option<ChessMove>>,
     sel_depth: u32,
-    h_table: RefCell<HistoryTable>,
-    ch_table: RefCell<HistoryTable>,
+    h_table: HistoryTable,
+    ch_table: HistoryTable,
     killer_moves: Vec<MoveEntry<{ SEARCH_PARAMS.get_k_move_cnt() }>>,
     threat_moves: Vec<MoveEntry<{ SEARCH_PARAMS.get_threat_move_cnt() }>>,
     nodes: u32,
@@ -234,13 +234,23 @@ impl LocalContext {
     }
 
     #[inline]
-    pub fn get_h_table(&self) -> &RefCell<HistoryTable> {
+    pub fn get_h_table(&self) -> &HistoryTable {
         &self.h_table
     }
 
     #[inline]
-    pub fn get_ch_table(&self) -> &RefCell<HistoryTable> {
+    pub fn get_ch_table(&self) -> &HistoryTable {
         &self.ch_table
+    }
+
+    #[inline]
+    pub fn get_h_table_mut(&mut self) -> &mut HistoryTable {
+        &mut self.h_table
+    }
+
+    #[inline]
+    pub fn get_ch_table_mut(&mut self) -> &mut HistoryTable {
+        &mut self.ch_table
     }
 
     #[inline]
@@ -449,8 +459,8 @@ impl AbRunner {
             },
             local_context: LocalContext {
                 window: Window::new(WINDOW_START, WINDOW_FACTOR, WINDOW_DIVISOR, WINDOW_ADD),
-                h_table: RefCell::new(HistoryTable::new()),
-                ch_table: RefCell::new(HistoryTable::new()),
+                h_table: HistoryTable::new(),
+                ch_table: HistoryTable::new(),
                 killer_moves: vec![],
                 threat_moves: vec![],
                 tt_hits: 0,

--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -51,7 +51,7 @@ impl<const T: usize, const K: usize> OrderedMoveGen<T, K> {
         }
     }
 
-    pub fn next(&mut self, hist: Ref<HistoryTable>) -> Option<ChessMove> {
+    pub fn next(&mut self, hist: &HistoryTable) -> Option<ChessMove> {
         match self.gen_type {
             GenType::PvMove => {
                 self.gen_type = GenType::CalcCaptures;

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -264,7 +264,7 @@ pub fn search<Search: SearchType>(
     let mut quiets = ArrayVec::<ChessMove, 64>::new();
     let mut captures = ArrayVec::<ChessMove, 64>::new();
 
-    while let Some(make_move) = move_gen.next(local_context.get_h_table().borrow()) {
+    while let Some(make_move) = move_gen.next(local_context.get_h_table()) {
         if Some(make_move) == skip_move {
             continue;
         }
@@ -274,13 +274,13 @@ pub fn search<Search: SearchType>(
         let is_quiet = !in_check && !is_capture && !is_promotion;
 
         let h_score = if is_capture {
-            local_context.get_ch_table().borrow().get(
+            local_context.get_ch_table().get(
                 board.side_to_move(),
                 board.piece_on(make_move.get_source()).unwrap(),
                 make_move.get_dest(),
             )
         } else {
-            local_context.get_h_table().borrow().get(
+            local_context.get_h_table().get(
                 board.side_to_move(),
                 board.piece_on(make_move.get_source()).unwrap(),
                 make_move.get_dest(),
@@ -492,13 +492,11 @@ pub fn search<Search: SearchType>(
                         let killer_table = local_context.get_k_table();
                         killer_table[ply as usize].push(make_move);
                         local_context
-                            .get_h_table()
-                            .borrow_mut()
+                            .get_h_table_mut()
                             .cutoff(&board, make_move, &quiets, depth);
                     } else {
                         local_context
-                            .get_ch_table()
-                            .borrow_mut()
+                            .get_ch_table_mut()
                             .cutoff(&board, make_move, &captures, depth);
                     }
 


### PR DESCRIPTION
Remove RefCell for potentially increased performance and more clear code