### PR TITLE
Capture history ordering

### DIFF
--- a/src/bm/bm_eval/evaluator.rs
+++ b/src/bm/bm_eval/evaluator.rs
@@ -268,9 +268,9 @@ impl StdEvaluator {
         }
     }
 
-    pub fn see(board: Board, make_move: Move) -> i16 {
+    pub fn see<const N: usize>(board: Board, make_move: Move) -> i16 {
         let mut index = 0;
-        let mut gains = [0_i16; 16];
+        let mut gains = [0_i16; N];
         let target_square = make_move.to;
         let move_piece = board.piece_on(make_move.from).unwrap();
         gains[0] = if let Some(piece) = board.piece_on(target_square) {
@@ -284,7 +284,7 @@ impl StdEvaluator {
         let mut color = !board.side_to_move();
         let mut blockers = board.occupied() & !make_move.from.bitboard();
         let mut last_piece_pts = Self::piece_pts(move_piece);
-        'outer: for i in 1..16 {
+        'outer: for i in 1..N {
             gains[i] = last_piece_pts - gains[i - 1];
             let defenders = board.colors(color) & blockers;
             for &piece in &Piece::ALL {

--- a/src/bm/bm_eval/evaluator.rs
+++ b/src/bm/bm_eval/evaluator.rs
@@ -268,7 +268,7 @@ impl StdEvaluator {
         }
     }
 
-    pub fn see<const N: usize>(board: Board, make_move: Move) -> i16 {
+    pub fn see<const N: usize>(board: &Board, make_move: Move) -> i16 {
         let mut index = 0;
         let mut gains = [0_i16; N];
         let target_square = make_move.to;

--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -92,10 +92,9 @@ impl<const T: usize, const K: usize> OrderedMoveGen<T, K> {
                     if Some(make_move) == self.pv_move {
                         continue;
                     }
-                    let mut expected_gain = c_hist
-                        .get(self.board.side_to_move(), piece_moves.piece, make_move.to)
-                        .max(StdEvaluator::see::<2>(self.board.clone(), make_move));
-                    if expected_gain < 0 {
+                    let mut expected_gain =
+                        c_hist.get(self.board.side_to_move(), piece_moves.piece, make_move.to);
+                    if StdEvaluator::see::<16>(self.board.clone(), make_move) < 0 {
                         expected_gain += LOSING_CAPTURE;
                     }
                     self.queue.push((make_move, expected_gain));

--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -92,9 +92,9 @@ impl<const T: usize, const K: usize> OrderedMoveGen<T, K> {
                     if Some(make_move) == self.pv_move {
                         continue;
                     }
-                    let piece = self.board.piece_on(make_move.from).unwrap();
-
-                    let mut expected_gain = c_hist.get(self.board.side_to_move(), piece, make_move.to);
+                    let mut expected_gain = c_hist
+                        .get(self.board.side_to_move(), piece_moves.piece, make_move.to)
+                        .max(StdEvaluator::see::<2>(self.board.clone(), make_move));
                     if expected_gain < 0 {
                         expected_gain += LOSING_CAPTURE;
                     }
@@ -248,7 +248,7 @@ impl<const SEE_PRUNE: bool> Iterator for QuiescenceSearchMoveGen<SEE_PRUNE> {
             self.board.generate_moves(|mut piece_moves| {
                 piece_moves.to &= self.board.colors(!self.board.side_to_move());
                 for make_move in piece_moves {
-                    let expected_gain = StdEvaluator::see(self.board.clone(), make_move);
+                    let expected_gain = StdEvaluator::see::<16>(self.board.clone(), make_move);
                     if !SEE_PRUNE || expected_gain > -1 {
                         let pos = self
                             .queue

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -401,7 +401,7 @@ pub fn search<Search: SearchType>(
             */
             let do_see_prune = !Search::PV && !in_check && depth <= 2;
             if do_see_prune
-                && eval + StdEvaluator::see(board.clone(), make_move) + SEARCH_PARAMS.get_fp()
+                && eval + StdEvaluator::see::<16>(board.clone(), make_move) + SEARCH_PARAMS.get_fp()
                     < alpha
             {
                 continue;

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -401,7 +401,7 @@ pub fn search<Search: SearchType>(
             */
             let do_see_prune = !Search::PV && !in_check && depth <= 2;
             if do_see_prune
-                && eval + StdEvaluator::see::<16>(board.clone(), make_move) + SEARCH_PARAMS.get_fp()
+                && eval + StdEvaluator::see::<16>(&board, make_move) + SEARCH_PARAMS.get_fp()
                     < alpha
             {
                 continue;

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -283,9 +283,11 @@ pub fn search<Search: SearchType>(
     let mut quiets = ArrayVec::<Move, 64>::new();
     let mut captures = ArrayVec::<Move, 64>::new();
 
-    while let Some(make_move) =
-        move_gen.next(local_context.get_h_table(), local_context.get_cm_hist())
-    {
+    while let Some(make_move) = move_gen.next(
+        local_context.get_h_table(),
+        local_context.get_ch_table(),
+        local_context.get_cm_hist(),
+    ) {
         if Some(make_move) == skip_move {
             continue;
         }


### PR DESCRIPTION
Order captures based on value of piece taken first, then capture history.
Decide good and bad captures based on SEE score.