### PR TITLE
Capture history ordering in qsearch

### DIFF
--- a/src/bm/bm_runner/ab_consts.rs
+++ b/src/bm/bm_runner/ab_consts.rs
@@ -35,7 +35,6 @@ pub const DO_LMP: bool = true;
 pub const QUIESCENCE_SEARCH_DEPTH: u32 = 30;
 pub const DELTA_MARGIN: i16 = 1000;
 pub const DO_DELTA_PRUNE: bool = true;
-pub const DO_SEE_PRUNE: bool = true;
 
 pub const FAIL_CNT: u8 = 10;
 pub const WINDOW_START: i16 = 25;

--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -45,7 +45,6 @@ pub const SEARCH_PARAMS: SearchParams = SearchParams {
     q_search_depth: QUIESCENCE_SEARCH_DEPTH,
     delta_margin: DELTA_MARGIN,
     do_dp: DO_DELTA_PRUNE,
-    do_see_prune: DO_SEE_PRUNE,
     h_reduce_divisor: HISTORY_REDUCTION_DIVISOR,
 };
 
@@ -71,7 +70,6 @@ pub struct SearchParams {
     q_search_depth: u32,
     delta_margin: i16,
     do_dp: bool,
-    do_see_prune: bool,
     h_reduce_divisor: i16,
 }
 
@@ -99,11 +97,6 @@ impl SearchParams {
     #[inline]
     pub const fn do_dp(&self) -> bool {
         self.do_dp
-    }
-
-    #[inline]
-    pub const fn do_see_prune(&self) -> bool {
-        self.do_see_prune
     }
 
     #[inline]

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -641,8 +641,8 @@ pub fn q_search(
         }
     }
 
-    let move_gen = QuiescenceSearchMoveGen::<{ SEARCH_PARAMS.do_see_prune() }>::new(&board);
-    for make_move in move_gen {
+    let mut move_gen = QuiescenceSearchMoveGen::new(&board);
+    while let Some(make_move) = move_gen.next(local_context.get_ch_table()) {
         let is_capture = board.colors(!board.side_to_move()).has(make_move.to);
         if in_check || is_capture {
             position.make_move(make_move);


### PR DESCRIPTION
Use captured material value first, capture history second for qsearch move ordering