### PR TITLE
Reset killer moves properly

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -240,7 +240,7 @@ pub fn search<Search: SearchType>(
         local_context.get_k_table().push(MoveEntry::new());
     }
 
-    if let Some(entry) = local_context.get_k_table().get_mut(ply as usize + 2) {
+    if let Some(entry) = local_context.get_k_table().get_mut(ply as usize + 1) {
         entry.clear();
     }
 


### PR DESCRIPTION
Resets next ply killers, instead of the killers of next 2 plies.