### PR TITLE
Include extensions for history depth

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -519,6 +519,7 @@ pub fn search<Search: SearchType>(
                 }
                 if score >= beta {
                     if !local_context.abort() {
+                        let amt = depth + extension;
                         if !is_capture {
                             let killer_table = local_context.get_k_table();
                             killer_table[ply as usize].push(make_move);
@@ -526,21 +527,21 @@ pub fn search<Search: SearchType>(
                                 pos.board(),
                                 make_move,
                                 &quiets,
-                                depth,
+                                amt,
                             );
                             if let Some(Some(prev_move)) = prev_move {
                                 local_context.get_cm_table_mut().cutoff(
                                     pos.board(),
                                     prev_move,
                                     make_move,
-                                    depth,
+                                    amt,
                                 );
                                 local_context.get_cm_hist_mut().cutoff(
                                     pos.board(),
                                     prev_move,
                                     make_move,
                                     &quiets,
-                                    depth,
+                                    amt,
                                 );
                             }
                         } else {
@@ -548,7 +549,7 @@ pub fn search<Search: SearchType>(
                                 pos.board(),
                                 make_move,
                                 &captures,
-                                depth,
+                                amt,
                             );
                         }
                     }

--- a/src/bm/bm_util/h_table.rs
+++ b/src/bm/bm_util/h_table.rs
@@ -23,9 +23,6 @@ impl HistoryTable {
     }
 
     pub fn cutoff(&mut self, board: &Board, make_move: Move, fails: &[Move], amt: u32) {
-        if amt > 20 {
-            return;
-        }
         let index = sq_index(board.side_to_move(), make_move.from);
         let to_index = make_move.to as usize;
 
@@ -113,9 +110,6 @@ impl DoubleMoveHistory {
         fails: &[Move],
         amt: u32,
     ) {
-        if amt > 20 {
-            return;
-        }
         let prev_piece = board.piece_on(prev_move.to).unwrap_or(Piece::King);
         let prev_index = piece_index(board.side_to_move(), prev_piece);
         let prev_to_index = prev_move.to as usize;


### PR DESCRIPTION
Modify history more aggressively if the move that caused a beta cutoff was extended.