### PR TITLE
Verification

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -209,13 +209,15 @@ pub fn search<Search: SearchType>(
         */
         if do_nmp::<Search>(pos.board(), depth, eval.raw(), beta.raw()) && pos.null_move() {
             local_context.search_stack_mut()[ply as usize].move_played = None;
+
+            let nmp_depth = nmp_depth(depth, eval.raw(), beta.raw());
             let zw = beta >> Next;
             let search_score = search::<NoNm>(
                 pos,
                 local_context,
                 shared_context,
                 ply + 1,
-                nmp_depth(depth, eval.raw(), beta.raw()),
+                nmp_depth,
                 zw,
                 zw + 1,
             );
@@ -229,7 +231,7 @@ pub fn search<Search: SearchType>(
                         local_context,
                         shared_context,
                         ply + 1,
-                        depth,
+                        nmp_depth,
                         alpha,
                         beta,
                     );

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -222,7 +222,22 @@ pub fn search<Search: SearchType>(
             pos.unmake_move();
             let score = search_score << Next;
             if score >= beta {
-                return score;
+                let mut verified = depth < 10;
+                if !verified {
+                    let verification = search::<NoNm>(
+                        pos,
+                        local_context,
+                        shared_context,
+                        ply + 1,
+                        depth,
+                        alpha,
+                        beta,
+                    );
+                    verified = verification >= beta;
+                }
+                if verified {
+                    return score;
+                }
             }
         }
     }


### PR DESCRIPTION
Add verifications search for positions where null move pruning prevents the engine from finding the best move. Elo neutral change, should be better in a small subset of positions.