### PR TITLE
History affected more for positions where eval doesn't beat alpha

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -539,7 +539,7 @@ pub fn search<Search: SearchType>(
                 }
                 if score >= beta {
                     if !local_context.abort() {
-                        let amt = depth + extension;
+                        let amt = depth + extension + (eval <= alpha) as u32;
                         if !is_capture {
                             let killer_table = local_context.get_k_table();
                             killer_table[ply as usize].push(make_move);


### PR DESCRIPTION
History factor gets incremented by one if eval doesn't beat alpha