### PR TITLE
Fix history change amount being over max history value

### DIFF
--- a/src/bm/bm_util/h_table.rs
+++ b/src/bm/bm_util/h_table.rs
@@ -27,7 +27,7 @@ impl HistoryTable {
         let to_index = make_move.to as usize;
 
         let value = self.table[index][to_index];
-        let change = (amt * amt) as i16;
+        let change = ((amt * amt) as i16).min(MAX_VALUE as i16);
         let decay = (change as i32 * value as i32 / MAX_VALUE) as i16;
 
         let increment = change - decay;
@@ -119,7 +119,7 @@ impl DoubleMoveHistory {
         let to_index = make_move.to as usize;
 
         let value = self.table[prev_index][prev_to_index][index][to_index];
-        let change = (amt * amt) as i16;
+        let change = ((amt * amt) as i16).min(MAX_VALUE as i16);
         let decay = (change as i32 * value as i32 / MAX_VALUE) as i16;
 
         let increment = change - decay;


### PR DESCRIPTION
History is always capped at 512 for correctness in move ordering.