### PR TITLE
Quiet best moves also punish capture history

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -556,14 +556,6 @@ pub fn search<Search: SearchType>(
                         if !is_capture {
                             let killer_table = local_context.get_k_table();
                             killer_table[ply as usize].push(make_move);
-
-                            local_context.get_hist_mut().update_quiet(
-                                pos,
-                                &hist_indices,
-                                make_move,
-                                &quiets,
-                                amt as i16,
-                            );
                             if let Some(prev_move) = prev_move {
                                 local_context.get_cm_table_mut().cutoff(
                                     pos.board(),
@@ -572,11 +564,15 @@ pub fn search<Search: SearchType>(
                                     amt,
                                 );
                             }
-                        } else {
-                            local_context
-                                .get_hist_mut()
-                                .update_captures(pos, make_move, &captures, amt as i16);
                         }
+                        local_context.get_hist_mut().update_history(
+                            pos,
+                            &hist_indices,
+                            make_move,
+                            &quiets,
+                            &captures,
+                            amt as i16,
+                        );
                     }
                     break;
                 }

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -105,7 +105,30 @@ impl History {
         )
     }
 
-    pub fn update_quiet(
+    pub fn update_history(
+        &mut self,
+        pos: &Position,
+        indices: &HistoryIndices,
+        make_move: Move,
+        quiets: &[Move],
+        captures: &[Move],
+        amt: i16,
+    ) {
+        let is_capture = pos
+            .board()
+            .colors(!pos.board().side_to_move())
+            .has(make_move.to);
+        if !is_capture {
+            self.update_quiet(pos, indices, make_move, quiets, amt);
+        } else {
+            bonus(self.get_capture_mut(pos, make_move), amt);
+        }
+        for &failed_move in captures {
+            malus(self.get_capture_mut(pos, failed_move), amt);
+        }
+    }
+
+    fn update_quiet(
         &mut self,
         pos: &Position,
         indices: &HistoryIndices,
@@ -125,13 +148,6 @@ impl History {
                     .unwrap();
                 malus(failed_hist, amt);
             }
-        }
-    }
-
-    pub fn update_captures(&mut self, pos: &Position, make_move: Move, fails: &[Move], amt: i16) {
-        bonus(self.get_capture_mut(pos, make_move), amt);
-        for &failed_move in fails {
-            malus(self.get_capture_mut(pos, failed_move), amt);
         }
     }
 }


### PR DESCRIPTION
If the best move is quiet, all captures get punished in the history table.