### PR TITLE
Fuh avg

### DIFF
--- a/src/bm/bm_runner/ab_runner.rs
+++ b/src/bm/bm_runner/ab_runner.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use cozy_chess::{Board, Color, Move};
+use cozy_chess::{Board, Color, Move, Piece, Square};
 
 use crate::bm::bm_runner::config::{GuiInfo, NoInfo, SearchMode, SearchStats};
 use crate::bm::bm_search::move_entry::MoveEntry;
@@ -68,11 +68,32 @@ pub struct SharedContext {
     lmp_lookup: Arc<LmpLookup>,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub struct MoveData {
+    pub from: Square,
+    pub to: Square,
+    pub promotion: Option<Piece>,
+    pub piece: Piece,
+    pub capture: bool,
+}
+
+impl MoveData {
+    pub fn from_move(board: &Board, make_move: Move) -> Self {
+        Self {
+            from: make_move.from,
+            to: make_move.to,
+            promotion: make_move.promotion,
+            piece: board.piece_on(make_move.from).unwrap(),
+            capture: board.colors(!board.side_to_move()).has(make_move.to),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SearchStack {
     pub eval: Evaluation,
     pub skip_move: Option<Move>,
-    pub move_played: Option<Move>,
+    pub move_played: Option<MoveData>,
     pub pv: [Option<Move>; MAX_PLY as usize + 1],
     pub pv_len: usize,
 }

--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -166,7 +166,11 @@ impl<const K: usize> OrderedMoveGen<K> {
                     let counter_move_hist = hist
                         .get_counter_move(pos, hist_indices, make_move)
                         .unwrap_or_default();
-                    let score = hist.get_quiet(pos, make_move) + counter_move_hist;
+                    let followup_move_hist = hist
+                        .get_followup_move(pos, hist_indices, make_move)
+                        .unwrap_or_default();
+                    let score =
+                        hist.get_quiet(pos, make_move) + counter_move_hist + followup_move_hist;
 
                     self.quiets.push((make_move, score));
                 }

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -287,6 +287,12 @@ pub fn search<Search: SearchType>(
         None
     };
 
+    let prev_stm_move = if ply > 1 {
+        local_context.search_stack()[ply as usize - 2].move_played
+    } else {
+        None
+    };
+
     let counter_move = if let Some(prev_move) = prev_move {
         local_context.get_cm_table().get(
             pos.board().side_to_move(),
@@ -307,7 +313,7 @@ pub fn search<Search: SearchType>(
     let mut quiets = ArrayVec::<Move, 64>::new();
     let mut captures = ArrayVec::<Move, 64>::new();
 
-    let hist_indices = HistoryIndices::new(pos, prev_move);
+    let hist_indices = HistoryIndices::new(pos, prev_move, prev_stm_move);
     while let Some(make_move) = move_gen.next(pos, local_context.get_hist(), &hist_indices) {
         if Some(make_move) == skip_move {
             continue;

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -328,7 +328,16 @@ pub fn search<Search: SearchType>(
         let h_score = if is_capture {
             local_context.get_hist().get_capture(pos, make_move)
         } else {
-            local_context.get_hist().get_quiet(pos, make_move)
+            (local_context.get_hist().get_quiet(pos, make_move)
+                + local_context
+                    .get_hist()
+                    .get_counter_move(pos, &hist_indices, make_move)
+                    .unwrap_or_default()
+                + local_context
+                    .get_hist()
+                    .get_followup_move(pos, &hist_indices, make_move)
+                    .unwrap_or_default())
+                / 3
         };
         local_context.search_stack_mut()[ply as usize + 1].pv_len = 0;
 

--- a/src/bm/bm_util/counter_move.rs
+++ b/src/bm/bm_util/counter_move.rs
@@ -1,5 +1,7 @@
 use cozy_chess::{Board, Color, Move, Piece, Square};
 
+use crate::bm::bm_runner::ab_runner::MoveData;
+
 use super::table_types::{new_piece_to_table, PieceTo};
 
 #[derive(Debug, Clone)]
@@ -18,13 +20,12 @@ impl CounterMoveTable {
         self.table[color as usize][piece as usize][to as usize]
     }
 
-    pub fn cutoff(&mut self, board: &Board, prev_move: Move, cutoff_move: Move, amt: u32) {
+    pub fn cutoff(&mut self, board: &Board, prev_move: MoveData, cutoff_move: Move, amt: u32) {
         if amt > 20 {
             return;
         }
         let color = board.side_to_move();
-        let piece = board.piece_on(prev_move.to).unwrap_or(Piece::King);
-        let to = prev_move.to;
-        self.table[color as usize][piece as usize][to as usize] = Some(cutoff_move);
+        self.table[color as usize][prev_move.piece as usize][prev_move.to as usize] =
+            Some(cutoff_move);
     }
 }

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -36,13 +36,12 @@ impl HistoryIndices {
             let piece = pos.board().piece_on(prev_move.to).unwrap_or(Piece::King);
             (piece, prev_move.to)
         });
-        let followup_move = prev_stm_move.map(|prev_stm_move| {
-            let piece = pos
-                .last(1)
-                .piece_on(prev_stm_move.to)
-                .unwrap_or(Piece::King);
-            (piece, prev_stm_move.to)
-        });
+        let followup_move = prev_stm_move
+            .zip(pos.last(1))
+            .map(|(prev_stm_move, board)| {
+                let piece = board.piece_on(prev_stm_move.to).unwrap_or(Piece::King);
+                (piece, prev_stm_move.to)
+            });
         Self {
             counter_move,
             followup_move,

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -143,7 +143,7 @@ impl History {
         let stm = pos.board().side_to_move();
         let current_piece = pos.board().piece_on(make_move.from).unwrap();
         Some(
-            &mut self.counter_move[stm as usize][prev_piece as usize][prev_to as usize]
+            &mut self.followup_move[stm as usize][prev_piece as usize][prev_to as usize]
                 [current_piece as usize][make_move.to as usize],
         )
     }

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -1,5 +1,7 @@
 use cozy_chess::{Color, Move, Piece, Square};
 
+use crate::bm::bm_runner::ab_runner::MoveData;
+
 use super::position::Position;
 use super::table_types::{new_butterfly_table, new_piece_to_table, Butterfly, PieceTo};
 
@@ -31,17 +33,10 @@ pub struct HistoryIndices {
 }
 
 impl HistoryIndices {
-    pub fn new(pos: &Position, prev_move: Option<Move>, prev_stm_move: Option<Move>) -> Self {
-        let counter_move = prev_move.map(|prev_move| {
-            let piece = pos.board().piece_on(prev_move.to).unwrap_or(Piece::King);
-            (piece, prev_move.to)
-        });
-        let followup_move = prev_stm_move
-            .zip(pos.last(1))
-            .map(|(prev_stm_move, board)| {
-                let piece = board.piece_on(prev_stm_move.to).unwrap_or(Piece::King);
-                (piece, prev_stm_move.to)
-            });
+    pub fn new(prev_move: Option<MoveData>, prev_stm_move: Option<MoveData>) -> Self {
+        let counter_move = prev_move.map(|prev_move| (prev_move.piece, prev_move.to));
+        let followup_move =
+            prev_stm_move.map(|prev_stm_move| (prev_stm_move.piece, prev_stm_move.to));
         Self {
             counter_move,
             followup_move,

--- a/src/bm/bm_util/history.rs
+++ b/src/bm/bm_util/history.rs
@@ -27,15 +27,26 @@ fn malus(hist: &mut i16, amt: i16) {
 #[derive(Copy, Clone)]
 pub struct HistoryIndices {
     counter_move: Option<(Piece, Square)>,
+    followup_move: Option<(Piece, Square)>,
 }
 
 impl HistoryIndices {
-    pub fn new(pos: &Position, prev_move: Option<Move>) -> Self {
+    pub fn new(pos: &Position, prev_move: Option<Move>, prev_stm_move: Option<Move>) -> Self {
         let counter_move = prev_move.map(|prev_move| {
             let piece = pos.board().piece_on(prev_move.to).unwrap_or(Piece::King);
             (piece, prev_move.to)
         });
-        Self { counter_move }
+        let followup_move = prev_stm_move.map(|prev_stm_move| {
+            let piece = pos
+                .last(1)
+                .piece_on(prev_stm_move.to)
+                .unwrap_or(Piece::King);
+            (piece, prev_stm_move.to)
+        });
+        Self {
+            counter_move,
+            followup_move,
+        }
     }
 }
 
@@ -44,6 +55,7 @@ pub struct History {
     quiet: Box<[Butterfly<i16>; Color::NUM]>,
     capture: Box<[Butterfly<i16>; Color::NUM]>,
     counter_move: Box<[PieceTo<PieceTo<i16>>; Color::NUM]>,
+    followup_move: Box<[PieceTo<PieceTo<i16>>; Color::NUM]>,
 }
 
 impl History {
@@ -52,6 +64,7 @@ impl History {
             quiet: Box::new([new_butterfly_table(0); Color::NUM]),
             capture: Box::new([new_butterfly_table(0); Color::NUM]),
             counter_move: Box::new([new_piece_to_table(new_piece_to_table(0)); Color::NUM]),
+            followup_move: Box::new([new_piece_to_table(new_piece_to_table(0)); Color::NUM]),
         }
     }
 
@@ -105,6 +118,36 @@ impl History {
         )
     }
 
+    pub fn get_followup_move(
+        &self,
+        pos: &Position,
+        indices: &HistoryIndices,
+        make_move: Move,
+    ) -> Option<i16> {
+        let (prev_piece, prev_to) = indices.followup_move?;
+        let stm = pos.board().side_to_move();
+        let current_piece = pos.board().piece_on(make_move.from).unwrap();
+        Some(
+            self.followup_move[stm as usize][prev_piece as usize][prev_to as usize]
+                [current_piece as usize][make_move.to as usize],
+        )
+    }
+
+    fn get_followup_move_mut(
+        &mut self,
+        pos: &Position,
+        indices: &HistoryIndices,
+        make_move: Move,
+    ) -> Option<&mut i16> {
+        let (prev_piece, prev_to) = indices.followup_move?;
+        let stm = pos.board().side_to_move();
+        let current_piece = pos.board().piece_on(make_move.from).unwrap();
+        Some(
+            &mut self.counter_move[stm as usize][prev_piece as usize][prev_to as usize]
+                [current_piece as usize][make_move.to as usize],
+        )
+    }
+
     pub fn update_history(
         &mut self,
         pos: &Position,
@@ -145,6 +188,15 @@ impl History {
             for &failed_move in fails {
                 let failed_hist = self
                     .get_counter_move_mut(pos, indices, failed_move)
+                    .unwrap();
+                malus(failed_hist, amt);
+            }
+        }
+        if let Some(followup_move_hist) = self.get_followup_move_mut(pos, indices, make_move) {
+            bonus(followup_move_hist, amt);
+            for &failed_move in fails {
+                let failed_hist = self
+                    .get_followup_move_mut(pos, indices, failed_move)
                     .unwrap();
                 malus(failed_hist, amt);
             }

--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -57,6 +57,11 @@ impl Position {
     }
 
     #[inline]
+    pub fn last(&self, index: usize) -> &Board {
+        &self.boards[self.boards.len() - index]
+    }
+
+    #[inline]
     pub fn half_ply(&self) -> u8 {
         self.current.halfmove_clock()
     }

--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -57,11 +57,6 @@ impl Position {
     }
 
     #[inline]
-    pub fn last(&self, index: usize) -> Option<&Board> {
-        self.boards.get(self.boards.len() - index)
-    }
-
-    #[inline]
     pub fn half_ply(&self) -> u8 {
         self.current.halfmove_clock()
     }

--- a/src/bm/bm_util/position.rs
+++ b/src/bm/bm_util/position.rs
@@ -57,8 +57,8 @@ impl Position {
     }
 
     #[inline]
-    pub fn last(&self, index: usize) -> &Board {
-        &self.boards[self.boards.len() - index]
+    pub fn last(&self, index: usize) -> Option<&Board> {
+        self.boards.get(self.boards.len() - index)
     }
 
     #[inline]


### PR DESCRIPTION
Add followup move history
Cleaner code via the usage of MoveData instead of getting data from all board states
Average all histories for pruning

Some of these changes are to be simplified in the future