### PR TITLE
Remove followup move history from move ordering

### DIFF
--- a/src/bm/bm_search/move_gen.rs
+++ b/src/bm/bm_search/move_gen.rs
@@ -166,11 +166,7 @@ impl<const K: usize> OrderedMoveGen<K> {
                     let counter_move_hist = hist
                         .get_counter_move(pos, hist_indices, make_move)
                         .unwrap_or_default();
-                    let followup_move_hist = hist
-                        .get_followup_move(pos, hist_indices, make_move)
-                        .unwrap_or_default();
-                    let score =
-                        hist.get_quiet(pos, make_move) + counter_move_hist + followup_move_hist;
+                    let score = hist.get_quiet(pos, make_move) + counter_move_hist;
 
                     self.quiets.push((make_move, score));
                 }


### PR DESCRIPTION
Followup move history doesn't improve move ordering