### PR TITLE
Save counter moves above depth 20

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -585,7 +585,6 @@ pub fn search<Search: SearchType>(
                                     pos.board(),
                                     prev_move,
                                     make_move,
-                                    amt,
                                 );
                             }
                         }

--- a/src/bm/bm_util/counter_move.rs
+++ b/src/bm/bm_util/counter_move.rs
@@ -20,10 +20,7 @@ impl CounterMoveTable {
         self.table[color as usize][piece as usize][to as usize]
     }
 
-    pub fn cutoff(&mut self, board: &Board, prev_move: MoveData, cutoff_move: Move, amt: u32) {
-        if amt > 20 {
-            return;
-        }
+    pub fn cutoff(&mut self, board: &Board, prev_move: MoveData, cutoff_move: Move) {
         let color = board.side_to_move();
         self.table[color as usize][prev_move.piece as usize][prev_move.to as usize] =
             Some(cutoff_move);


### PR DESCRIPTION
Simplify out counter moves not being saved at depths higher than 20