### PR TITLE
Threat Avoid Extensions

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -377,7 +377,7 @@ pub fn search<Search: SearchType>(
             extension = extension.max(1);
         }
 
-        if Search::PV && nstm_threats.has(make_move.from) {
+        if Search::PV && nstm_threats.has(make_move.from) && is_capture {
             extension = extension.max(1);
         }
 

--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -377,6 +377,10 @@ pub fn search<Search: SearchType>(
             extension = extension.max(1);
         }
 
+        if Search::PV && nstm_threats.has(make_move.from) {
+            extension = extension.max(1);
+        }
+
         let non_mate_line = highest_score.map_or(false, |s: Evaluation| !s.is_mate());
         /*
         In non-PV nodes If a move isn't good enough to beat alpha - a static margin


### PR DESCRIPTION
Extend captures that also avoid threats in PV nodes