### PR TITLE
Remove beta score comparison from history formula

### DIFF
--- a/src/bm/bm_search/search.rs
+++ b/src/bm/bm_search/search.rs
@@ -599,7 +599,7 @@ pub fn search<Search: SearchType>(
                 }
                 if score >= beta {
                     if !thread.abort {
-                        let amt = depth + (eval <= initial_alpha) as u32 + (score - 50 > beta) as u32;
+                        let amt = depth + (eval <= initial_alpha) as u32;
                         if !is_capture {
                             thread.killer_moves[ply as usize].push(make_move);
                         }


### PR DESCRIPTION
Passed STC simplification
```
Elo   | 0.87 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 24890 W: 6151 L: 6089 D: 12650
Penta | [164, 2966, 6150, 2974, 191]
```

Passed LTC simplification
```
Elo   | 0.02 +- 1.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 43590 W: 10565 L: 10562 D: 22463
Penta | [98, 4995, 11581, 5048, 73]
```